### PR TITLE
Expand description for warp_mouse_position method

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -383,7 +383,8 @@
 			<return type="void" />
 			<argument index="0" name="to" type="Vector2" />
 			<description>
-				Sets the mouse position to the specified vector.
+				Sets the mouse position to the specified vector, provided in pixels and relative to an origin at the upper left corner of the game window.
+				Mouse position is clipped to the limits of the screen resolution, or to the limits of the game window if [enum MouseMode] is set to [code]MOUSE_MODE_CONFINED[/code] or [code]MOUSE_MODE_CONFINED_HIDDEN[/code].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Add more detail to the description for the warp_mouse_position method, clarifying that the vector is provided in screen coordinates and relative to an origin at the top of the game window.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
